### PR TITLE
Install the Playwright Python package in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install jupyter pyyaml
+          python -m pip install playwright
           pip install ./vendor/rhythmpress
 
       - name: Install Chromium for social-card rendering


### PR DESCRIPTION
Add an explicit python -m pip install playwright step before invoking python -m playwright install --with-deps chromium in the deploy workflow.

The previous workflow added browser provisioning but still failed on GitHub Actions because the Playwright module itself was not installed on the fresh runner environment.